### PR TITLE
Fix relative request paths

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8407,7 +8407,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8513,7 +8514,8 @@
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -14128,7 +14130,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14337,7 +14340,8 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
@@ -14362,6 +14366,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -14543,7 +14548,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14599,6 +14605,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14642,12 +14649,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15054,7 +15063,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15082,6 +15092,7 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15096,7 +15107,8 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -15107,7 +15119,8 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -15224,7 +15237,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -15236,6 +15250,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -15250,6 +15265,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -15257,12 +15273,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15281,6 +15299,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -15342,7 +15361,8 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -15370,7 +15390,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -15382,6 +15403,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -15459,7 +15481,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -15495,6 +15518,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15514,6 +15538,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -15557,12 +15582,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/dashboard/src/app/services/crud.service.ts
+++ b/dashboard/src/app/services/crud.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs';
-import {environment} from '../../environments/environment.prod';
 import {PasswordEntry} from '../models/password-entry';
 
 @Injectable({
@@ -16,22 +15,20 @@ export class CrudService {
     responseType: 'text' as 'json'
   };
 
-  apiUrl = environment.apiUrl;
-
   constructor(
     private httpClient: HttpClient
   ) {
   }
 
   getListOfPasswords(): Observable<any> {
-    return this.httpClient.get(`${this.apiUrl}/passwords`, this.httpOptions);
+    return this.httpClient.get(`/passwords`, this.httpOptions);
   }
 
   addPassword(body: PasswordEntry): Observable<any> {
-    return this.httpClient.post<PasswordEntry>(`${this.apiUrl}/password`, JSON.stringify(body), this.httpOptions);
+    return this.httpClient.post<PasswordEntry>(`/password`, JSON.stringify(body), this.httpOptions);
   }
 
   deletePassword(body: PasswordEntry): Observable<any> {
-    return this.httpClient.request<PasswordEntry>('delete', `${this.apiUrl}/password`, {body: JSON.stringify(body)});
+    return this.httpClient.request<PasswordEntry>('delete', `/password`, {body: JSON.stringify(body)});
   }
 }

--- a/dashboard/src/app/services/custom-interceptor.ts
+++ b/dashboard/src/app/services/custom-interceptor.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
-import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse} from '@angular/common/http';
+import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {Observable} from 'rxjs';
+import {environment} from '../../environments/environment.prod';
 
 @Injectable({providedIn: 'root'})
 export class CustomInterceptor implements HttpInterceptor {
@@ -9,9 +10,13 @@ export class CustomInterceptor implements HttpInterceptor {
   }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    req = req.clone({
+    // console.log's for debugginggit add
+    console.log(req);
+    const apiReq = req.clone({
+      url: `https://${environment.apiUrl}${req.url}`,
       withCredentials: true
     });
-    return next.handle(req);
+    console.log(apiReq);
+    return next.handle(apiReq);
   }
 }

--- a/dashboard/src/app/services/user.service.ts
+++ b/dashboard/src/app/services/user.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs';
-import {environment} from '../../environments/environment.prod';
 import {User} from '../models/user';
 import {UserRegister} from '../models/user-register';
 
@@ -15,44 +14,42 @@ export class UserService {
     responseType: 'text' as 'json'
   };
 
-  apiUrl = environment.apiUrl;
-
   constructor(
     private httpClient: HttpClient
   ) {
   }
 
   getUser(): Observable<any> {
-    return this.httpClient.get<User>(`${this.apiUrl}/user`, this.httpOptions);
+    return this.httpClient.get<User>(`/user`, this.httpOptions);
   }
 
   register(body: UserRegister): Observable<any> {
-    return this.httpClient.post<UserRegister>(`${this.apiUrl}/standard/register`, JSON.stringify(body),
+    return this.httpClient.post<UserRegister>(`/standard/register`, JSON.stringify(body),
       this.httpOptions);
   }
 
   login(body: User): Observable<any> {
-    return this.httpClient.post<User>(`${this.apiUrl}/standard/login`, JSON.stringify(body),
+    return this.httpClient.post<User>(`/standard/login`, JSON.stringify(body),
       this.httpOptions);
   }
 
   logout(): Observable<any> {
-    return this.httpClient.post(`${this.apiUrl}/logout`, '', this.httpOptions);
+    return this.httpClient.post(`/logout`, '', this.httpOptions);
   }
 
   webauthnRegistrationStart(body: UserRegister): Observable<any> {
-    return this.httpClient.post<UserRegister>(`${this.apiUrl}/webauthn/registration/start`, JSON.stringify(body), this.httpOptions);
+    return this.httpClient.post<UserRegister>(`/webauthn/registration/start`, JSON.stringify(body), this.httpOptions);
   }
 
   webauthnRegistrationFinish(body: any): Observable<any> {
-    return this.httpClient.post(`${this.apiUrl}/webauthn/registration/finish`, JSON.stringify(body), this.httpOptions);
+    return this.httpClient.post(`/webauthn/registration/finish`, JSON.stringify(body), this.httpOptions);
   }
 
   webauthnLoginStart(body: UserRegister): Observable<any> {
-    return this.httpClient.post<UserRegister>(`${this.apiUrl}/webauthn/login/start`, JSON.stringify(body), this.httpOptions);
+    return this.httpClient.post<UserRegister>(`/webauthn/login/start`, JSON.stringify(body), this.httpOptions);
   }
 
   webauthnLoginFinish(body: any): Observable<any> {
-    return this.httpClient.post(`${this.apiUrl}/webauthn/login/finish`, JSON.stringify(body), this.httpOptions);
+    return this.httpClient.post(`/webauthn/login/finish`, JSON.stringify(body), this.httpOptions);
   }
 }

--- a/dashboard/src/environments/environment.prod.ts
+++ b/dashboard/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: location.host
+  apiUrl: `${location.hostname}`,
 };

--- a/dashboard/src/environments/environment.ts
+++ b/dashboard/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: location.host
+  apiUrl: `${location.hostname}`,
 };
 
 /*


### PR DESCRIPTION
This hopefully resolves #75.  
It could be that this fix will not work because of the usage of the --base-href parameter in the build, but we'll have to see in the deployed version.  
If that is the case, we might have to revise the usage of that parameter. However, the usage of `lcoation.hostname` instead of `location.host` should only deliver the TLD as described [here](https://stackoverflow.com/a/11379802/12141469).